### PR TITLE
Make logo link to homepage and adjust search bar expansion

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,9 +57,18 @@
 
         /* 搜尋優化 */
         @media (max-width: 639px) {
+            #header.search-active #logo-title-container,
+            #header.search-active #main-nav {
+                display: none;
+            }
+
             #header.search-active #search-container {
                 width: 100%;
                 flex-grow: 1;
+            }
+
+            #header.search-active #search-cancel-btn {
+                display: block;
             }
         }
     </style>
@@ -239,8 +248,6 @@
     const header = document.getElementById('header');
     const searchContainer = document.getElementById('search-container');
     const searchCancelBtn = document.getElementById('search-cancel-btn');
-    const logoTitleContainer = document.getElementById('logo-title-container');
-    const mainNav = document.getElementById('main-nav');
     let currentIndex = 0;
     let intervalId;
     let trpgData = []; // 存放從 JSON 讀取的資料
@@ -665,18 +672,12 @@
 
     // --- 搜尋啟用/停用邏輯 ---
     function activateSearch() {
-        if (window.innerWidth < 640) {
-            header.classList.add('search-active');
-            logoTitleContainer.classList.add('hidden');
-            mainNav.classList.add('hidden');
-            searchCancelBtn.classList.remove('hidden');
-        }
+        header.classList.add('search-active');
+        searchCancelBtn.classList.remove('hidden');
     }
 
     function deactivateSearch() {
         header.classList.remove('search-active');
-        logoTitleContainer.classList.remove('hidden');
-        mainNav.classList.remove('hidden');
         searchCancelBtn.classList.add('hidden');
         searchInput.value = '';
         searchResultsList.classList.add('hidden');

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
     <div class="container mx-auto px-4 py-4 flex justify-between items-center">
         <a id="logo-title-container" href="https://firesidetales.vercel.app/" class="flex items-center space-x-4 flex-shrink-0 no-underline">
             <img src="img/favicon-32x32.png" alt="網站Logo" class="w-8 h-8">
-            <span class="hidden sm:inline text-3xl font-bold text-gray-100">說書人的爐邊夜話</span>
+            <span class="text-xl sm:text-3xl font-bold text-gray-100">說書人的爐邊夜話</span>
         </a>
         <div class="flex items-center justify-end flex-grow">
             <div id="search-container" class="relative mr-2 sm:mr-6 w-20 transition-all duration-300 sm:w-32 sm:focus-within:w-64">
@@ -98,9 +98,9 @@
                 <div id="search-results-list" class="absolute top-full left-0 mt-2 w-full max-h-[70vh] overflow-y-auto bg-gray-800 rounded-lg shadow-xl hidden"></div>
             </div>
             <nav id="main-nav" class="flex items-center space-x-6">
-                <a href="#" class="hidden sm:block text-lg font-semibold text-gray-300 hover:text-indigo-400 transition-colors">首頁</a>
-                <a href="#archive" class="hidden sm:block text-lg font-semibold text-gray-300 hover:text-indigo-400 transition-colors">團錄清單</a>
-                <a href="#" class="hidden sm:block text-lg font-semibold text-gray-300 hover:text-indigo-400 transition-colors" id="about-us-btn">關於我們</a>
+                <a href="#" class="text-base sm:text-lg font-semibold text-gray-300 hover:text-indigo-400 transition-colors">首頁</a>
+                <a href="#archive" class="text-base sm:text-lg font-semibold text-gray-300 hover:text-indigo-400 transition-colors">團錄清單</a>
+                <a href="#" class="text-base sm:text-lg font-semibold text-gray-300 hover:text-indigo-400 transition-colors" id="about-us-btn">關於我們</a>
             </nav>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -77,12 +77,12 @@
 <!-- 頂部導覽列 (Header) -->
 <header id="header" class="bg-gray-900 shadow-lg fixed w-full top-0 z-50">
     <div class="container mx-auto px-4 py-4 flex justify-between items-center">
-        <div id="logo-title-container" class="flex items-center space-x-4 flex-shrink-0">
+        <a id="logo-title-container" href="https://firesidetales.vercel.app/" class="flex items-center space-x-4 flex-shrink-0 no-underline">
             <img src="img/favicon-32x32.png" alt="網站Logo" class="w-8 h-8">
             <span class="hidden sm:inline text-3xl font-bold text-gray-100">說書人的爐邊夜話</span>
-        </div>
+        </a>
         <div class="flex items-center justify-end flex-grow">
-            <div id="search-container" class="relative mr-2 sm:mr-6 w-full sm:w-auto">
+            <div id="search-container" class="relative mr-2 sm:mr-6 w-full sm:w-32 sm:focus-within:w-64 transition-all duration-300">
                 <div class="relative flex items-center w-full bg-gray-800 rounded-full focus-within:ring-2 focus-within:ring-indigo-500">
                     <i class="fas fa-search absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400"></i>
                     <div id="search-tags-input-container" class="flex items-center gap-2 pl-10 pr-4 py-1 w-full">

--- a/index.html
+++ b/index.html
@@ -57,18 +57,9 @@
 
         /* 搜尋優化 */
         @media (max-width: 639px) {
-            #header.search-active #logo-title-container {
-                display: none;
-            }
             #header.search-active #search-container {
                 width: 100%;
                 flex-grow: 1;
-            }
-            #header.search-active #main-nav {
-                display: none;
-            }
-            #header:not(.search-active) #search-cancel-btn {
-                display: none;
             }
         }
     </style>
@@ -248,6 +239,8 @@
     const header = document.getElementById('header');
     const searchContainer = document.getElementById('search-container');
     const searchCancelBtn = document.getElementById('search-cancel-btn');
+    const logoTitleContainer = document.getElementById('logo-title-container');
+    const mainNav = document.getElementById('main-nav');
     let currentIndex = 0;
     let intervalId;
     let trpgData = []; // 存放從 JSON 讀取的資料
@@ -674,12 +667,16 @@
     function activateSearch() {
         if (window.innerWidth < 640) {
             header.classList.add('search-active');
+            logoTitleContainer.classList.add('hidden');
+            mainNav.classList.add('hidden');
             searchCancelBtn.classList.remove('hidden');
         }
     }
 
     function deactivateSearch() {
         header.classList.remove('search-active');
+        logoTitleContainer.classList.remove('hidden');
+        mainNav.classList.remove('hidden');
         searchCancelBtn.classList.add('hidden');
         searchInput.value = '';
         searchResultsList.classList.add('hidden');

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
                 display: none;
             }
             #header.search-active #search-container {
+                width: 100%;
                 flex-grow: 1;
             }
             #header.search-active #main-nav {
@@ -82,12 +83,12 @@
             <span class="hidden sm:inline text-3xl font-bold text-gray-100">說書人的爐邊夜話</span>
         </a>
         <div class="flex items-center justify-end flex-grow">
-            <div id="search-container" class="relative mr-2 sm:mr-6 w-full sm:w-32 sm:focus-within:w-64 transition-all duration-300">
+            <div id="search-container" class="relative mr-2 sm:mr-6 w-20 transition-all duration-300 sm:w-32 sm:focus-within:w-64">
                 <div class="relative flex items-center w-full bg-gray-800 rounded-full focus-within:ring-2 focus-within:ring-indigo-500">
                     <i class="fas fa-search absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400"></i>
                     <div id="search-tags-input-container" class="flex items-center gap-2 pl-10 pr-4 py-1 w-full">
                         <!-- 搜尋關鍵字標籤 -->
-                        <input type="text" placeholder="搜尋或新增標籤..." class="bg-transparent text-gray-200 focus:outline-none flex-grow min-w-[100px]" id="search-input">
+                        <input type="text" placeholder="搜尋或新增標籤..." class="bg-transparent text-gray-200 focus:outline-none flex-grow min-w-0 sm:min-w-[100px]" id="search-input">
                     </div>
                     <button id="search-cancel-btn" class="hidden sm:hidden absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-white">
                         <i class="fas fa-times-circle"></i>


### PR DESCRIPTION
## Summary
- Link logo and title to the Fireside Tales homepage
- Let the search bar expand on focus to keep nav options visible on smaller screens

## Testing
- `npx --yes htmlhint index.html` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68b1484468f4832bb576b58b02fb3009